### PR TITLE
Automatically deploy to master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 tmp
 mixture.json
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+
+deploy:
+  provider: script
+  script: npm run deploy
+  skip_cleanup: true
+  on:
+    branch: master

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "stateofwebtype",
   "version": "0.1.0",
+  "engines": {
+    "node": "6.9.x"
+  },
   "devDependencies": {
     "grunt": "~0.4.5",
     "grunt-contrib-sass": "~0.9.2",
@@ -12,6 +15,11 @@
     "grunt-mkdir": "^0.1.2",
     "node-sass": "^3.11.3",
     "assetgraph-builder": "^3.11.0",
-    "livestyle": "^2.0.2"
+    "livestyle": "^2.0.2",
+    "surge": "latest"
+  },
+  "scripts": {
+    "predeploy": "grunt",
+    "deploy": "surge ./dist stateofwebtype.com"
   }
 }


### PR DESCRIPTION
State of Web Type should be automatically compiled and deployed when something is pushed to the `master` branch. This also means that if people open PRs for data, typos, etc. we can merge them and the site will automatically be rebuilt and published too.

The site could be hosted on [Surge.sh](http://surge.sh) (full disclosure, I helped build it) but most of this is still usable even if you decide you want it on GitHub Pages instead. Only the `deploy` script in the `package.json` file would change (probably using [gh-pages](https://npm.im/gh-pages)).

Some things that would need still to happen:

- [x] Open PR for deploy and `.travis.yml` script
- [x] [Create a Surge account](https://surge.sh/help/getting-started-with-surge) @bramstein 
- [x] Add Bram as a collaborator on Surge
- [x] [Generate a token for Travis](https://surge.sh/help/integrating-with-travis-ci)
- [x] Set this repository up on Travis @kennethormandy
- [x] Merge PR @bramstein
- [x] Change the DNS settings for the domain [to point to Surge](https://surge.sh/help/adding-a-custom-domain) (I’ve deployed it once, so it will show up automatically once it’s switched)